### PR TITLE
Replacing :bdel with :bw to completely wipe the buffer off-memory (fo…

### DIFF
--- a/plugin/BufOnly.vim
+++ b/plugin/BufOnly.vim
@@ -51,7 +51,7 @@ function! BufOnly(buffer, bang)
 							\ n '(add ! to override)'
 				echohl None
 			else
-				silent exe 'bdel' . a:bang . ' ' . n
+				silent exe 'bw' . a:bang . ' ' . n
 				if ! buflisted(n)
 					let delete_count = delete_count+1
 				endif


### PR DESCRIPTION
Replacing :bdel with :bw to completely wipe the buffer off-memory (for compatibility with Command-T)

Using :BufOnly in conjunction with Command-T causes a glitch - when closing all buffers and then trying to reopen one of the buffers which was closed with Command-T, you get it in split window instead of tab, because vim seems to be storing information about that buffer being opened somewhere. :bw doesn't have that issue.
